### PR TITLE
Fix SSH cleaning

### DIFF
--- a/rados-bench-gen
+++ b/rados-bench-gen
@@ -50,10 +50,12 @@ do
     r)
         REPLICA_COUNT="${OPTARG}"
         ;;
+    s)
+        HOSTS="${OPTARG}"
+        ;;
     z)
         THREAD="${OPTARG}"
         ;;
-
     h)
         usage
         ;;


### PR DESCRIPTION
The HOST var was declared so HOST was empty.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
